### PR TITLE
feat: referrals for not-yet-applied candidates (ATS-56)

### DIFF
--- a/server/prisma/migrations/20260827080000_extend_referrals/migration.sql
+++ b/server/prisma/migrations/20260827080000_extend_referrals/migration.sql
@@ -1,0 +1,10 @@
+-- Referrals for candidates who may not have applied yet (ATS-56)
+
+ALTER TABLE "referrals" ALTER COLUMN "candidateId" DROP NOT NULL;
+
+ALTER TABLE "referrals" ADD COLUMN IF NOT EXISTS "referredFirstName" TEXT;
+ALTER TABLE "referrals" ADD COLUMN IF NOT EXISTS "referredLastName" TEXT;
+ALTER TABLE "referrals" ADD COLUMN IF NOT EXISTS "referredEmail" TEXT;
+ALTER TABLE "referrals" ADD COLUMN IF NOT EXISTS "referredByUserId" TEXT NOT NULL DEFAULT 'system';
+
+CREATE INDEX IF NOT EXISTS "referrals_referredByUserId_idx" ON "referrals"("referredByUserId");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -610,15 +610,22 @@ model RoundTwo {
 }
 
 model Referral {
-  id           String           @id @default(uuid())
-  referrerName String
-  relationship String
-  candidateId  String
-  createdAt    DateTime         @default(now())
-  cycleId      String?
-  candidate    Candidate        @relation(fields: [candidateId], references: [id])
-  cycle        RecruitingCycle? @relation(fields: [cycleId], references: [id])
+  id                String           @id @default(uuid())
+  referrerName      String
+  relationship      String
+  candidateId       String?
+  cycleId           String?
+  referredFirstName String?
+  referredLastName  String?
+  referredEmail     String?
+  referredByUserId  String
+  createdAt         DateTime         @default(now())
+  candidate         Candidate?       @relation(fields: [candidateId], references: [id])
+  cycle             RecruitingCycle? @relation(fields: [cycleId], references: [id])
 
+  @@index([cycleId])
+  @@index([candidateId])
+  @@index([referredByUserId])
   @@map("referrals")
 }
 

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6069,4 +6069,27 @@ router.get('/talent-pool/stats', async (req, res) => {
   }
 });
 
+// -------------------- Admin Referral List (ATS-56) --------------------
+
+// List referrals scoped by cycle/candidate; includes not-yet-applied candidates
+router.get('/referrals', async (req, res) => {
+  try {
+    const { cycleId, candidateId } = req.query || {};
+    const where = {};
+    if (cycleId) where.cycleId = String(cycleId);
+    if (candidateId) where.candidateId = String(candidateId);
+
+    const referrals = await prisma.referral.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      include: { candidate: true }
+    });
+
+    res.json(referrals);
+  } catch (error) {
+    console.error('[GET /api/admin/referrals]', error);
+    res.status(500).json({ error: 'Failed to fetch referrals' });
+  }
+});
+
 export default router;

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,44 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// Member referral submissions (ATS-56)
+router.post('/referrals', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { cycleId, candidateId, referrerName, relationship, referredFirstName, referredLastName, referredEmail } = req.body || {};
+
+    if (!cycleId) {
+      return res.status(400).json({ error: 'cycleId is required' });
+    }
+
+    if (!candidateId && (!referredFirstName || !referredLastName)) {
+      return res.status(400).json({ error: 'Either candidateId or referred first and last name are required' });
+    }
+
+    if (candidateId) {
+      const candidate = await prisma.candidate.findUnique({ where: { id: candidateId } });
+      if (!candidate) {
+        return res.status(404).json({ error: 'Candidate not found' });
+      }
+    }
+
+    const referral = await prisma.referral.create({
+      data: {
+        cycleId,
+        candidateId: candidateId || null,
+        referrerName: referrerName || req.user.fullName || 'Unknown',
+        relationship: relationship || '',
+        referredFirstName: referredFirstName || null,
+        referredLastName: referredLastName || null,
+        referredEmail: referredEmail || null,
+        referredByUserId: req.user.id
+      }
+    });
+
+    res.status(201).json(referral);
+  } catch (error) {
+    console.error('[POST /api/member/referrals]', error);
+    res.status(500).json({ error: 'Failed to create referral' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Extends referrals so members can submit them for candidates who have not applied yet.\n\n- Makes Referral.candidateId optional\n- Adds referred first/last name, email, and referring member tracking\n- Member POST /api/member/referrals and admin GET /api/admin/referrals\n\nCloses ATS-56