### PR TITLE
feat: admin vote session confirmation (ATS-54)

### DIFF
--- a/server/prisma/migrations/20260827050000_add_live_voting/migration.sql
+++ b/server/prisma/migrations/20260827050000_add_live_voting/migration.sql
@@ -1,0 +1,52 @@
+-- Live deliberation voting tables (ATS-54 / ATS-67)
+
+CREATE TABLE IF NOT EXISTS "vote_sessions" (
+    "id" TEXT NOT NULL,
+    "cycleId" TEXT NOT NULL,
+    "deliberationId" TEXT,
+    "candidateId" TEXT,
+    "name" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "requiredVotes" INTEGER,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "closedAt" TIMESTAMP(3),
+    CONSTRAINT "vote_sessions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "vote_options" (
+    "id" TEXT NOT NULL,
+    "voteSessionId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "vote_options_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "votes" (
+    "id" TEXT NOT NULL,
+    "voteSessionId" TEXT NOT NULL,
+    "optionId" TEXT NOT NULL,
+    "voterId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "votes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "vote_sessions_cycleId_idx" ON "vote_sessions"("cycleId");
+CREATE INDEX IF NOT EXISTS "vote_sessions_deliberationId_idx" ON "vote_sessions"("deliberationId");
+CREATE INDEX IF NOT EXISTS "vote_sessions_candidateId_idx" ON "vote_sessions"("candidateId");
+CREATE INDEX IF NOT EXISTS "vote_options_voteSessionId_idx" ON "vote_options"("voteSessionId");
+CREATE INDEX IF NOT EXISTS "votes_voteSessionId_idx" ON "votes"("voteSessionId");
+CREATE INDEX IF NOT EXISTS "votes_optionId_idx" ON "votes"("optionId");
+CREATE UNIQUE INDEX IF NOT EXISTS "votes_voteSessionId_voterId_key" ON "votes"("voteSessionId", "voterId");
+
+ALTER TABLE "vote_options" DROP CONSTRAINT IF EXISTS "vote_options_voteSessionId_fkey";
+ALTER TABLE "vote_options" ADD CONSTRAINT "vote_options_voteSessionId_fkey" FOREIGN KEY ("voteSessionId") REFERENCES "vote_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "votes" DROP CONSTRAINT IF EXISTS "votes_voteSessionId_fkey";
+ALTER TABLE "votes" ADD CONSTRAINT "votes_voteSessionId_fkey" FOREIGN KEY ("voteSessionId") REFERENCES "vote_sessions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "votes" DROP CONSTRAINT IF EXISTS "votes_optionId_fkey";
+ALTER TABLE "votes" ADD CONSTRAINT "votes_optionId_fkey" FOREIGN KEY ("optionId") REFERENCES "vote_options"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260827090000_add_vote_session_confirmation/migration.sql
+++ b/server/prisma/migrations/20260827090000_add_vote_session_confirmation/migration.sql
@@ -1,0 +1,5 @@
+-- Vote session final confirmation fields (ATS-54)
+
+ALTER TABLE "vote_sessions" ADD COLUMN IF NOT EXISTS "confirmedOptionId" TEXT;
+ALTER TABLE "vote_sessions" ADD COLUMN IF NOT EXISTS "confirmedBy" TEXT;
+ALTER TABLE "vote_sessions" ADD COLUMN IF NOT EXISTS "confirmedAt" TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -910,6 +910,9 @@ model VoteSession {
   createdAt       DateTime        @default(now())
   updatedAt       DateTime        @updatedAt
   closedAt        DateTime?
+  confirmedOptionId String?
+  confirmedBy     String?
+  confirmedAt     DateTime?
   options         VoteOption[]
   votes           Vote[]
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -898,6 +898,59 @@ model Message {
   @@map("messages")
 }
 
+model VoteSession {
+  id              String          @id @default(uuid())
+  cycleId         String
+  deliberationId  String?
+  candidateId     String?
+  name            String
+  status          VoteSessionStatus @default(DRAFT)
+  requiredVotes   Int?
+  createdBy       String
+  createdAt       DateTime        @default(now())
+  updatedAt       DateTime        @updatedAt
+  closedAt        DateTime?
+  options         VoteOption[]
+  votes           Vote[]
+
+  @@index([cycleId])
+  @@index([deliberationId])
+  @@index([candidateId])
+  @@map("vote_sessions")
+}
+
+model VoteOption {
+  id            String      @id @default(uuid())
+  voteSessionId String
+  label         String
+  value         String
+  createdAt     DateTime    @default(now())
+  voteSession   VoteSession @relation(fields: [voteSessionId], references: [id], onDelete: Cascade)
+  votes         Vote[]
+
+  @@map("vote_options")
+}
+
+model Vote {
+  id            String      @id @default(uuid())
+  voteSessionId String
+  optionId      String
+  voterId       String
+  createdAt     DateTime    @default(now())
+  updatedAt     DateTime    @updatedAt
+  option        VoteOption  @relation(fields: [optionId], references: [id], onDelete: Cascade)
+  voteSession   VoteSession @relation(fields: [voteSessionId], references: [id], onDelete: Cascade)
+
+  @@unique([voteSessionId, voterId])
+  @@map("votes")
+}
+
+enum VoteSessionStatus {
+  DRAFT
+  OPEN
+  CLOSED
+}
+
 enum ConversationContextType {
   INTERVIEW
   APPLICATION

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6069,4 +6069,154 @@ router.get('/talent-pool/stats', async (req, res) => {
   }
 });
 
+// -------------------- Live Deliberation Voting (ATS-54 / ATS-67) --------------------
+
+// Create a new vote session with options
+router.post('/vote-sessions', async (req, res) => {
+  try {
+    const { cycleId, deliberationId, candidateId, name, options, requiredVotes } = req.body || {};
+
+    if (!cycleId || !name || !Array.isArray(options) || options.length < 2) {
+      return res.status(400).json({ error: 'cycleId, name, and at least two options are required' });
+    }
+
+    const session = await prisma.$transaction(async (tx) => {
+      const created = await tx.voteSession.create({
+        data: {
+          cycleId,
+          deliberationId: deliberationId || null,
+          candidateId: candidateId || null,
+          name,
+          requiredVotes: requiredVotes != null ? Number(requiredVotes) : null,
+          createdBy: req.user.id
+        }
+      });
+
+      const optionRecords = await Promise.all(options.map((o, idx) =>
+        tx.voteOption.create({
+          data: {
+            voteSessionId: created.id,
+            label: String(o.label || o.value || `Option ${idx + 1}`),
+            value: String(o.value || o.label || idx)
+          }
+        })
+      ));
+
+      return { ...created, options: optionRecords };
+    });
+
+    res.status(201).json(session);
+  } catch (error) {
+    console.error('[POST /api/admin/vote-sessions]', error);
+    res.status(500).json({ error: 'Failed to create vote session' });
+  }
+});
+
+// List vote sessions for a cycle
+router.get('/vote-sessions', async (req, res) => {
+  try {
+    const { cycleId } = req.query;
+    const where = {};
+    if (cycleId) where.cycleId = String(cycleId);
+
+    const sessions = await prisma.voteSession.findMany({
+      where,
+      orderBy: { createdAt: 'desc' },
+      include: {
+        options: true,
+        _count: { select: { votes: true } }
+      }
+    });
+
+    res.json(sessions);
+  } catch (error) {
+    console.error('[GET /api/admin/vote-sessions]', error);
+    res.status(500).json({ error: 'Failed to list vote sessions' });
+  }
+});
+
+// Get a vote session with live tally
+router.get('/vote-sessions/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const session = await prisma.voteSession.findUnique({
+      where: { id },
+      include: { options: true }
+    });
+
+    if (!session) {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+
+    const voteCounts = await prisma.vote.groupBy({
+      by: ['optionId'],
+      where: { voteSessionId: id },
+      _count: { _all: true }
+    });
+
+    const totalVotes = voteCounts.reduce((sum, v) => sum + v._count._all, 0);
+    const optionTally = session.options.map((opt) => {
+      const found = voteCounts.find((vc) => vc.optionId === opt.id);
+      const count = found ? found._count._all : 0;
+      return {
+        ...opt,
+        count,
+        percentage: totalVotes > 0 ? Math.round((count / totalVotes) * 1000) / 10 : 0
+      };
+    });
+
+    res.json({ ...session, totalVotes, options: optionTally });
+  } catch (error) {
+    console.error('[GET /api/admin/vote-sessions/:id]', error);
+    res.status(500).json({ error: 'Failed to fetch vote session' });
+  }
+});
+
+// Update vote session status (OPEN / CLOSED)
+router.patch('/vote-sessions/:id/status', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body || {};
+
+    if (!status || !['DRAFT', 'OPEN', 'CLOSED'].includes(status)) {
+      return res.status(400).json({ error: 'status must be DRAFT, OPEN, or CLOSED' });
+    }
+
+    const data = { status };
+    if (status === 'CLOSED') data.closedAt = new Date();
+
+    const session = await prisma.voteSession.update({
+      where: { id },
+      data,
+      include: { options: true }
+    });
+
+    res.json(session);
+  } catch (error) {
+    console.error('[PATCH /api/admin/vote-sessions/:id/status]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+    res.status(500).json({ error: 'Failed to update vote session status' });
+  }
+});
+
+// Delete a vote session
+router.delete('/vote-sessions/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    await prisma.voteSession.delete({ where: { id } });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error('[DELETE /api/admin/vote-sessions/:id]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+    res.status(500).json({ error: 'Failed to delete vote session' });
+  }
+});
+
 export default router;

--- a/server/src/routes/admin.js
+++ b/server/src/routes/admin.js
@@ -6202,6 +6202,50 @@ router.patch('/vote-sessions/:id/status', async (req, res) => {
   }
 });
 
+// Admin confirm vote result and lock final decision (ATS-54)
+router.patch('/vote-sessions/:id/confirm', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { optionId } = req.body || {};
+
+    if (!optionId) {
+      return res.status(400).json({ error: 'optionId is required' });
+    }
+
+    const session = await prisma.voteSession.findUnique({
+      where: { id },
+      include: { options: true }
+    });
+
+    if (!session) {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+
+    const option = session.options.find((o) => o.id === optionId);
+    if (!option) {
+      return res.status(400).json({ error: 'Invalid option for this session' });
+    }
+
+    const updated = await prisma.voteSession.update({
+      where: { id },
+      data: {
+        confirmedOptionId: optionId,
+        confirmedBy: req.user.id,
+        confirmedAt: new Date()
+      },
+      include: { options: true }
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error('[PATCH /api/admin/vote-sessions/:id/confirm]', error);
+    if (error.code === 'P2025') {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+    res.status(500).json({ error: 'Failed to confirm vote session' });
+  }
+});
+
 // Delete a vote session
 router.delete('/vote-sessions/:id', async (req, res) => {
   try {

--- a/server/src/routes/member.js
+++ b/server/src/routes/member.js
@@ -2027,4 +2027,56 @@ router.delete('/resume', requireAuth, requireMemberRole, async (req, res) => {
   }
 });
 
+// Cast or change a vote in an open session (ATS-54 / ATS-67)
+router.post('/vote-sessions/:sessionId/vote', requireAuth, requireAdminOrMember, async (req, res) => {
+  try {
+    const { sessionId } = req.params;
+    const { optionId } = req.body || {};
+    const userId = req.user.id;
+
+    if (!optionId) {
+      return res.status(400).json({ error: 'optionId is required' });
+    }
+
+    const session = await prisma.voteSession.findUnique({
+      where: { id: sessionId },
+      include: { options: true }
+    });
+
+    if (!session) {
+      return res.status(404).json({ error: 'Vote session not found' });
+    }
+
+    if (session.status !== 'OPEN') {
+      return res.status(400).json({ error: 'Voting is not open for this session' });
+    }
+
+    const option = session.options.find((o) => o.id === optionId);
+    if (!option) {
+      return res.status(400).json({ error: 'Invalid option for this session' });
+    }
+
+    const existing = await prisma.vote.findFirst({
+      where: { voteSessionId: sessionId, voterId: userId }
+    });
+
+    let vote;
+    if (existing) {
+      vote = await prisma.vote.update({
+        where: { id: existing.id },
+        data: { optionId }
+      });
+    } else {
+      vote = await prisma.vote.create({
+        data: { voteSessionId: sessionId, optionId, voterId: userId }
+      });
+    }
+
+    res.json({ ...vote, option: { label: option.label, value: option.value } });
+  } catch (error) {
+    console.error('[POST /api/member/vote-sessions/:sessionId/vote]', error);
+    res.status(500).json({ error: 'Failed to cast vote' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
Implements the admin final-confirmation step for live deliberation voting (ATS-54).\n\n- Adds confirmedOptionId, confirmedBy, confirmedAt to VoteSession\n- Adds PATCH /api/admin/vote-sessions/:id/confirm\n- Audit trail remains the existing Vote records (voter, option, timestamp)\n\nCloses ATS-54